### PR TITLE
Fix buffer size property name in sample configurations

### DIFF
--- a/src/main/samples/dynamodb/DynamoDBSample.properties
+++ b/src/main/samples/dynamodb/DynamoDBSample.properties
@@ -9,7 +9,7 @@ retryLimit = 3
 
 # Flush when buffer exceeds 25 Kinesis records, 1 MB size limit or when time since last emit exceeds 1 hour
 # 1MB = 1024*1024 = 1048756
-bufferSizeByteLimit = 1048576 
+bufferByteSizeLimit = 1048576
 bufferRecordCountLimit = 25
 bufferMillisecondsLimit = 3600000
 

--- a/src/main/samples/redshiftbasic/RedshiftBasicSample.properties
+++ b/src/main/samples/redshiftbasic/RedshiftBasicSample.properties
@@ -9,7 +9,7 @@ retryLimit = 3
 
 # Flush when buffer exceeds 25 Kinesis records, 1 MB size limit or when time since last emit exceeds 1 hour
 # 1MB = 1024*1024 = 1048756
-bufferSizeByteLimit = 1048576 
+bufferByteSizeLimit = 1048576
 bufferRecordCountLimit = 25
 bufferMillisecondsLimit = 3600000
 

--- a/src/main/samples/redshiftmanifest/RedshiftManifestSample.properties
+++ b/src/main/samples/redshiftmanifest/RedshiftManifestSample.properties
@@ -8,7 +8,7 @@ regionName = us-east-1
 retryLimit = 3
 
 # Flush when buffer exceeds 8 Kinesis records, 1 KB size limit or when time since last emit exceeds 10 minutes
-bufferSizeByteLimit = 1024 
+bufferByteSizeLimit = 1024
 bufferRecordCountLimit = 8
 bufferMillisecondsLimit = 600000
 

--- a/src/main/samples/redshiftmanifest/S3ManifestSample.properties
+++ b/src/main/samples/redshiftmanifest/S3ManifestSample.properties
@@ -9,7 +9,7 @@ retryLimit = 3
 
 # Flush when buffer exceeds 25 Kinesis records, 1 MB size limit when time since last emit exceeds 1 hour
 # 1MB = 1024*1024 = 1048756
-bufferSizeByteLimit = 1048576 
+bufferByteSizeLimit = 1048576
 bufferRecordCountLimit = 25
 bufferMillisecondsLimit = 3600000
 

--- a/src/main/samples/s3/S3Sample.properties
+++ b/src/main/samples/s3/S3Sample.properties
@@ -7,7 +7,7 @@ appName = kinesisToS3
 regionName = us-east-1
 retryLimit = 3
 # 1MB = 1024*1024 = 1048756
-bufferSizeByteLimit = 1048576 
+bufferByteSizeLimit = 1048576
 bufferRecordCountLimit = 25
 bufferMillisecondsLimit = 3600000
 #Flush when buffer exceeds 25 Kinesis records, 1 MB size limit or when time since last buffer exceeds 1 hour


### PR DESCRIPTION
All the sample configuration files refer to `bufferSizeByteLimit` while the correct property name is `bufferByteSizeLimit`, [as you can see here](https://github.com/awslabs/amazon-kinesis-connectors/blob/master/src/main/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorConfiguration.java#L71).

This had me scratching my head for a long while, as size limits had no effect in actual use (record count and millisecond work fine!)