### PR TITLE
Added maven packaging and deployment supports.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,6 @@
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.10.1</version>
-        <configuration>
-          <!-- TODO: Remove this option after fixing javadoc. -->
-          <additionalJOption>-Xdoclint:-html,-missing</additionalJOption>
-        </configuration>
         <executions>
           <execution>
             <id>javadoc-jar</id>
@@ -88,4 +84,24 @@
       <optional>true</optional>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <!-- TODO: Remove this profile after fixing javadoc. -->
+    <profile>
+      <id>java8</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <additionalJOption>-Xdoclint:-html,-missing</additionalJOption>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.amazonaws</groupId>
+  <artifactId>amazon-kinesis-connectors</artifactId>
+  <version>1.1.1</version>
+  <packaging>jar</packaging>
+  <name>Amazon Kinesis Connectors</name>
+  <description>Amazon Kinesis Connector Library for Java</description>
+  <url>https://github.com/awslabs/amazon-kinesis-connectors</url>
+  <licenses>
+    <license>
+      <name>Amazon Software License</name>
+      <url>http://aws.amazon.com/asl/</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <scm>
+    <connection>scm:git:git@github.com:awslabs/amazon-kinesis-connectors.git</connection>
+    <url>scm:git:git@github.com:awslabs/amazon-kinesis-connectors.git</url>
+    <developerConnection>scm:git:git@github.com:awslabs/amazon-kinesis-connectors.git</developerConnection>
+  </scm>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.2</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.5</version>
+        <configuration>
+          <archive>
+            <manifestFile>META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <id>source-jar</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.1</version>
+        <configuration>
+          <!-- TODO: Remove this option after fixing javadoc. -->
+          <additionalJOption>-Xdoclint:-html,-missing</additionalJOption>
+        </configuration>
+        <executions>
+          <execution>
+            <id>javadoc-jar</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>amazon-kinesis-client</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <version>1.2.1</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
The original amazon-kinesis-connectors github project doesn't provide an easy means to build the source code.  Further, for people who simply wants to use the library, there isn't any convenient way to pull the library into their project.  This pull request provides a maven pom.xml file that one can use to build the "main" parts of the library; it also provides scm configurations for the amazon team to deploy the library to maven repository if they decide to do so.
- It generates all three jars: jar, source-jar, and javadoc-jar.
- It handles javadoc errors under JDK 8 by temporarily disabling some -Xlint options.
- Jar signing configuration is not included.
- Samples are not included in the build (yet).