### PR TITLE
If input stream is bigger then 128KB, you must define Content-Length

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/connectors/s3/S3Emitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/s3/S3Emitter.java
@@ -28,6 +28,7 @@ import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration;
 import com.amazonaws.services.kinesis.connectors.UnmodifiableBuffer;
 import com.amazonaws.services.kinesis.connectors.interfaces.IEmitter;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 
 /**
  * This implementation of IEmitter is used to store files from an Amazon Kinesis stream in S3. The use of
@@ -81,7 +82,9 @@ public class S3Emitter implements IEmitter<byte[]> {
         try {
             ByteArrayInputStream object = new ByteArrayInputStream(baos.toByteArray());
             LOG.debug("Starting upload of file " + s3URI + " to Amazon S3 containing " + records.size() + " records.");
-            s3client.putObject(s3Bucket, s3FileName, object, null);
+            ObjectMetadata meta = new ObjectMetadata();
+            meta.setContentLength(baos.size());
+            s3client.putObject(s3Bucket, s3FileName, object, meta);
             LOG.info("Successfully emitted " + buffer.getRecords().size() + " records to Amazon S3 in " + s3URI);
             return Collections.emptyList();
         } catch (Exception e) {


### PR DESCRIPTION
Fixes exception:
com.amazonaws.ResetException: Content length exceeded the reset buffer limit of 131073;  If the request involves an input stream, the maximum stream buffer size can be configured via request.getRequestClientOptions().setReadLimit(int)
	at com.amazonaws.services.s3.internal.AWSS3V4Signer.getContentLength(AWSS3V4Signer.java:148)
	at com.amazonaws.services.s3.internal.AWSS3V4Signer.calculateContentHash(AWSS3V4Signer.java:95)
	at com.amazonaws.auth.AWS4Signer.sign(AWS4Signer.java:195)
	at com.amazonaws.http.AmazonHttpClient.executeOneRequest(AmazonHttpClient.java:652)
	at com.amazonaws.http.AmazonHttpClient.executeHelper(AmazonHttpClient.java:460)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:295)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:3714)
	at com.amazonaws.services.s3.AmazonS3Client.putObject(AmazonS3Client.java:1445)
	at com.amazonaws.services.s3.AmazonS3Client.putObject(AmazonS3Client.java:1314)
	at com.amazonaws.services.kinesis.connectors.s3.S3Emitter.emit(S3Emitter.java:84)