### PR TITLE
Set content length when emitting manifest.

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/connectors/redshift/RedshiftManifestEmitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/redshift/RedshiftManifestEmitter.java
@@ -29,6 +29,7 @@ import java.util.Properties;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -183,8 +184,11 @@ public class RedshiftManifestEmitter implements IEmitter<String> {
     private String writeManifestToS3(String fileName, List<String> records) throws IOException {
         String fileContents = generateManifestFile(records);
         // upload generated manifest file
+        byte[] bytes = fileContents.getBytes();
+        ObjectMetadata meta = new ObjectMetadata();
+        meta.setContentLength(bytes.length);
         PutObjectRequest putObjectRequest =
-                new PutObjectRequest(s3Bucket, fileName, new ByteArrayInputStream(fileContents.getBytes()), null);
+                new PutObjectRequest(s3Bucket, fileName, new ByteArrayInputStream(bytes), meta);
         s3Client.putObject(putObjectRequest);
         return fileName;
     }


### PR DESCRIPTION
Every time that the library writes a manifest file to S3 the S3Client is logging a warning because the content length is not set.

"No content length specified for stream data.  Stream contents will be buffered in memory and could result in out of memory errors"

There is a PR that has been merged that fixed this issue just for the S3Emitter (https://github.com/awslabs/amazon-kinesis-connectors/pull/39/files). We need to fix this when we write the manifest file as well.
