### PR TITLE
Catch all exceptions in Record Processor instead of just IOException.

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessor.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessor.java
@@ -126,8 +126,18 @@ public class KinesisConnectorRecordProcessor<T, U> implements IRecordProcessor {
                 } else {
                     throw new RuntimeException("Transformer must implement ITransformer or ICollectionTransformer");
                 }
-            } catch (IOException e) {
+            } catch (Exception e) {
                 LOG.error(e);
+                try {
+                    final String lastSequenceNumberProcessed = buffer.getLastSequenceNumber();
+                    checkpointer.checkpoint(lastSequenceNumberProcessed);
+                } catch (InvalidStateException e1) {
+                    LOG.error("Checkpointing failed.");
+                    e1.printStackTrace();
+                } catch (ShutdownException e1) {
+                    LOG.error("Checkpointing failed.");
+                    e1.printStackTrace();
+                }
             }
         }
 


### PR DESCRIPTION
Checkpoint in the case of exception during record processing so that we don't go into an infinite loop of processing a bad record that throws an Exception.