### PR TITLE
elasticsearch 2.x support

### DIFF
--- a/pom.xml.elasticsearch-2.0.0
+++ b/pom.xml.elasticsearch-2.0.0
@@ -1,0 +1,124 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amazonaws</groupId>
+    <artifactId>amazon-kinesis-connectors</artifactId>
+    <packaging>jar</packaging>
+    <name>Amazon Kinesis Connector Library</name>
+    <version>1.2.0</version>
+    <description>The Amazon Kinesis Connector Library helps Java developers integrate Amazon Kinesis with other AWS and non-AWS services.</description>
+    <url>https://aws.amazon.com/kinesis</url>
+
+    <scm>
+        <url>https://github.com/awslabs/amazon-kinesis-connectors.git</url>
+    </scm>
+
+    <licenses>
+        <license>
+            <name>Amazon Software License</name>
+            <url>https://aws.amazon.com/asl</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <amazon-kinesis-client.version>1.4.0</amazon-kinesis-client.version>
+        <aws-java-sdk.version>1.9.37</aws-java-sdk.version>
+        <elasticsearch.version>2.0.0</elasticsearch.version>
+        <fasterxml-jackson.version>2.6.4</fasterxml-jackson.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>amazon-kinesis-client</artifactId>
+            <version>${amazon-kinesis-client.version}</version>
+        </dependency>
+        <!-- Note that some of dependencies below are shared with the Amazon Kinesis Client library. -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-kinesis</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-dynamodb</artifactId>
+            <version>${aws-java-sdk.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${aws-java-sdk.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${elasticsearch.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${fasterxml-jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${fasterxml-jackson.version}</version>
+        </dependency>
+    </dependencies>
+
+    <developers>
+        <developer>
+            <id>amazonwebservices</id>
+            <organization>Amazon Web Services</organization>
+            <organizationUrl>https://aws.amazon.com</organizationUrl>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.2</version>
+                    <configuration>
+                        <source>1.7</source>
+                        <target>1.7</target>
+                        <encoding>UTF-8</encoding>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/elasticsearch/Elasticsearch2Emitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/elasticsearch/Elasticsearch2Emitter.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.net.InetSocketAddress;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -31,7 +32,6 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.client.transport.NoNodeAvailableException;
 import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 
@@ -104,7 +104,7 @@ public class ElasticsearchEmitter implements IEmitter<ElasticsearchObject> {
 
     public ElasticsearchEmitter(KinesisConnectorConfiguration configuration) {
         Settings settings =
-                ImmutableSettings.settingsBuilder()
+                Settings.settingsBuilder()
                         .put(ELASTICSEARCH_CLUSTER_NAME_KEY, configuration.ELASTICSEARCH_CLUSTER_NAME)
                         .put(ELASTICSEARCH_CLIENT_TRANSPORT_SNIFF_KEY, configuration.ELASTICSEARCH_TRANSPORT_SNIFF)
                         .put(ELASTICSEARCH_CLIENT_TRANSPORT_IGNORE_CLUSTER_NAME_KEY,
@@ -115,9 +115,9 @@ public class ElasticsearchEmitter implements IEmitter<ElasticsearchObject> {
                         .build();
         elasticsearchEndpoint = configuration.ELASTICSEARCH_ENDPOINT;
         elasticsearchPort = configuration.ELASTICSEARCH_PORT;
-        LOG.info("ElasticsearchEmitter using elasticsearch endpoint " + elasticsearchEndpoint + ":" + elasticsearchPort);
-        elasticsearchClient = new TransportClient(settings);
-        elasticsearchClient.addTransportAddress(new InetSocketTransportAddress(elasticsearchEndpoint, elasticsearchPort));
+        LOG.info("Elasticsearch2Emitter using elasticsearch endpoint " + elasticsearchEndpoint + ":" + elasticsearchPort);
+        elasticsearchClient = TransportClient.builder().settings(settings).build();
+        elasticsearchClient.addTransportAddress(new InetSocketTransportAddress(new InetSocketAddress(elasticsearchEndpoint, elasticsearchPort)));
     }
 
     /**


### PR DESCRIPTION
## Purpose
Currently there is no elasticsearch 2.x.x support in the ```amazon-kinesis-connectors``` library. This PR is a first step forward towards getting support implemented.
### Status
WORK IN PROGRESS / NEED HELP
### Related Issues and PRs
- [Upgrade to a newer Elasticsearch version ?](https://github.com/awslabs/amazon-kinesis-connectors/issues/52)
- [Errors using consumer with ES 2.0](https://github.com/awslabs/cloudwatch-logs-subscription-consumer/issues/8)

### Background
I was enticed to use the [cloudwatch-logs-subscription-consumer](https://github.com/awslabs/cloudwatch-logs-subscription-consumer) by @DVassallo one day and went about trying to get it to work with our already implemented elasticsearch 2.0.0 installation in AWS. By figuring out what had changed between the 1.x and 2.x versions of elasticsearch ([great reference here](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_java_api_changes.html)) I was then able to go through the ```amazon-kinesis-connectors``` code and the ```cloudwatch-subscription-consumer``` code and make some changes to support 2.x. I then built a local ```.jar``` for ```amazon-kinesis-connectors``` after making some ```pom.xml``` changes. Followed by changes to ```cloudwatch-logs-subscription-consumer``` that fixed ```ImmutableSettings``` and re-wrote the ```ElasticsearchEmitter``` function to use the [methods outlined in the java api doc here](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_java_api_changes.html).

I was then able to make a successful connection to elasticsearch and see records start coming through. There are still a few things to iron out, they are outlined below. But the hope is, people who really need it can start using the configs in the PR and then soon it will be merged and fully functional.

### ToDos
- [ ] **The main issue** that remains is the ```ElasticsearchEmitter``` needs to be able to determine the elasticsearch version it is using from the ```pom.xml```, and then use the correct imports and function syntax. I am a newbie to Maven, and not a Java expert so this is beyond me for now.
- [ ] I didn't write any tests, nor did I notice any, they may need to be written?
- [ ] Documentation needs to be updated.

### Other Notes
- This was tested in Centos 6.7 and nowhere else.