### PR TITLE
Implement ConstantRecordCountMemoryBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ To run a sample, complete these steps:
 4. Within the sample folder, execute **ant run**.
 
 ## Release Notes
+### Release 1.2.3 (June 2, 2016)
++ Implement ConstantRecordCountMemoryBuffer.
+
 ### Release 1.2.0 (June 23, 2015)
 + Upgraded KCL to 1.4.0
 + Added pipelined record processor that decouples Amazon Kinesis GetRecords() and IRecordProcessor's ProcessRecords() API calls for efficiency.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>amazon-kinesis-connectors</artifactId>
     <packaging>jar</packaging>
     <name>Amazon Kinesis Connector Library</name>
-    <version>1.2.0</version>
+    <version>1.2.3</version>
     <description>The Amazon Kinesis Connector Library helps Java developers integrate Amazon Kinesis with other AWS and non-AWS services.</description>
     <url>https://aws.amazon.com/kinesis</url>
 

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/impl/ConstantRecordCountMemoryBuffer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/impl/ConstantRecordCountMemoryBuffer.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.kinesis.connectors.impl;
+
+import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration;
+import com.amazonaws.services.kinesis.connectors.interfaces.IBuffer;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * ConstantRecordCountMemoryBuffer is an implementation of the IBuffer interface.
+ * It ensures that records are periodically flushed with the same record count.
+ *
+ * Flushing a constant number of records is essential to the proper handling of
+ * duplicates on the consumer end as documented here:
+ *
+ * http://docs.aws.amazon.com/streams/latest/dev/kinesis-record-processor-duplicates.html
+ *
+ * @param <T>
+ */
+public class ConstantRecordCountMemoryBuffer<T> implements IBuffer<T> {
+
+    private final KinesisConnectorConfiguration configuration;
+    private final List<BasicMemoryBuffer<T>> buffers;
+    private BasicMemoryBuffer<T> currentBuffer;
+
+    public ConstantRecordCountMemoryBuffer(KinesisConnectorConfiguration configuration, List<BasicMemoryBuffer<T>> buffers) {
+        this.configuration = configuration;
+        this.buffers = buffers;
+        if (this.buffers.isEmpty()) {
+            currentBuffer = new BasicMemoryBuffer<T>(configuration);
+            buffers.add(currentBuffer);
+        }
+    }
+
+    public ConstantRecordCountMemoryBuffer(KinesisConnectorConfiguration configuration) {
+        this(configuration, new LinkedList<BasicMemoryBuffer<T>>());
+    }
+
+    @Override
+    public long getBytesToBuffer() {
+        return configuration.BUFFER_BYTE_SIZE_LIMIT;
+    }
+
+    @Override
+    public long getNumRecordsToBuffer() {
+        return configuration.BUFFER_RECORD_COUNT_LIMIT;
+    }
+
+    @Override
+    public long getMillisecondsToBuffer() {
+        return configuration.BUFFER_MILLISECONDS_LIMIT;
+    }
+
+    @Override
+    public void consumeRecord(T record, int recordSize, String sequenceNumber) {
+        assert(!buffers.isEmpty());
+
+        if (currentBuffer.getRecords().size() >= getNumRecordsToBuffer()) {
+            currentBuffer = new BasicMemoryBuffer<>(configuration);
+            buffers.add(currentBuffer);
+        }
+
+        currentBuffer.consumeRecord(record, recordSize, sequenceNumber);
+    }
+
+    @Override
+    public void clear() {
+        assert(!buffers.isEmpty());
+
+        if (buffers.size() == 1) {
+            currentBuffer.clear();
+        } else {
+           buffers.remove(0);
+        }
+    }
+
+    @Override
+    public String getFirstSequenceNumber() {
+        assert(!buffers.isEmpty());
+        return buffers.get(0).getFirstSequenceNumber();
+    }
+
+    @Override
+    public String getLastSequenceNumber() {
+        assert(!buffers.isEmpty());
+        return buffers.get(0).getLastSequenceNumber();
+    }
+
+    @Override
+    public boolean shouldFlush() {
+        assert(!buffers.isEmpty());
+        return buffers.get(0).shouldFlush();
+    }
+
+    @Override
+    public List<T> getRecords() {
+        assert(!buffers.isEmpty());
+        return buffers.get(0).getRecords();
+    }
+}


### PR DESCRIPTION
ConstantRecordCountMemoryBuffer is an implementation of the IBuffer interface. It ensures that records are periodically flushed with the same record count.

Flushing a constant number of records is essential to the proper handling of duplicates on the consumer end as documented here:

http://docs.aws.amazon.com/streams/latest/dev/kinesis-record-processor-duplicates.html
